### PR TITLE
Fix directory path construction in copy.py

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -532,7 +532,7 @@ class ActionModule(ActionBase):
             paths = os.path.split(source_rel)
             dir_path = ''
             for dir_component in paths:
-                os.path.join(dir_path, dir_component)
+                dir_path = os.path.join(dir_path, dir_component)
                 implicit_directories.add(dir_path)
             if 'diff' in result and not result['diff']:
                 del result['diff']

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -484,8 +484,10 @@ class ActionModule(ActionBase):
         # A list of source file tuples (full_path, relative_path) which will try to copy to the destination
         source_files = {'files': [], 'directories': [], 'symlinks': []}
 
+        source_is_dir = os.path.isdir(to_bytes(source, errors='surrogate_or_strict'))
+
         # If source is a directory populate our list else source is a file and translate it to a tuple.
-        if os.path.isdir(to_bytes(source, errors='surrogate_or_strict')):
+        if source_is_dir:
             # Get a list of the files we want to replicate on the remote side
             source_files = _walk_dirs(source, local_follow=local_follow,
                                       trailing_slash_detector=self._connection._shell.path_has_trailing_slash)
@@ -588,7 +590,7 @@ class ActionModule(ActionBase):
 
             changed = changed or module_return.get('changed', False)
 
-        if module_executed and len(source_files['files']) == 1:
+        if module_executed and not source_is_dir:
             result.update(module_return)
 
             # the file module returns the file path as 'path', but


### PR DESCRIPTION
##### SUMMARY

fixes #85833

First of all, the original Line 535 doesn't do anything.

I believe this is the root cause of issue #85833. If I understand the implementation correctly, the intention is to
1. (Line 484-501) Generate the list of source files, and organize them into `files`, `directories` and `symlinks`.
2. (Line 513-540) Copy files (including creating intermediate directories)
3. (Line 542-563) Copy directories (but exclude the directories that are already created in 2)
4. (Line 565-587) Copy symlinks
5. (Line 591-597) If the copy has happened and the source is a single file, include the last module return result in the action result. (Line 598-599) Otherwise, update the action return result.

The exclusion of directories in Step 2 didn't work because of the original Line 535. That's the cause of #85833 -- the intermediate directory was copied in Step 2 (it wasn't excluded properly), but since the directory was already created in Step 1, the last module return result was no change. As a result Step 5, returned the result of the directory copy, which was no change. After I fixed Line 535, I could verify #85833 is fixed.

In addition, if I understand it correctly, the intention to include the last module return result in Step 5 is only valid when the source is specified to be a file. Currently, when a directory that contains only one file is specified, the return result would be that file, which is strange. I've fixed this issue as well.

##### ISSUE TYPE

- Bugfix Pull Request
